### PR TITLE
Fix broken commands

### DIFF
--- a/cmd/content/content.go
+++ b/cmd/content/content.go
@@ -10,7 +10,6 @@ func GetContentCmd() *cobra.Command {
 		Use:   "content",
 		Short: "Commands for working with puppet content templates.",
 		Long:  "Commands for working with puppet content templates.",
-		Run:   nil,
 	}
 
 	cmd.AddCommand(getNewCmd())

--- a/cmd/content/list.go
+++ b/cmd/content/list.go
@@ -7,8 +7,12 @@ func getListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "Lists all installed templates.",
 		Long:  "Lists all installed templates.",
-		Run:   nil,
+		RunE:  listRunE,
 	}
 
 	return cmd
+}
+
+func listRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/content/new.go
+++ b/cmd/content/new.go
@@ -7,8 +7,12 @@ func getNewCmd() *cobra.Command {
 		Use:   "new",
 		Short: "Creates a Puppet project or other artifact based on a template.",
 		Long:  "Creates a Puppet project or other artifact based on a template.",
-		RunE:  nil,
+		RunE:  newRunE,
 	}
 
 	return cmd
+}
+
+func newRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -11,8 +11,12 @@ func GetExecCmd() *cobra.Command {
 		Use:   "exec",
 		Short: "Executes a given tool against some Puppet Content.",
 		Long:  "Executes a given tool against some Puppet Content.",
-		RunE:  nil,
+		RunE:  execRunE,
 	}
 
 	return cmd
+}
+
+func execRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/explain/explain.go
+++ b/cmd/explain/explain.go
@@ -11,8 +11,12 @@ func GetExplainCmd() *cobra.Command {
 		Use:   "explain",
 		Short: "Present documentation about topics.",
 		Long:  "Present documentation about topics.",
-		RunE:  nil,
+		RunE:  explainRunE,
 	}
 
 	return cmd
+}
+
+func explainRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/runtime/runtime.go
+++ b/cmd/runtime/runtime.go
@@ -12,7 +12,6 @@ func GetRuntimeCmd() *cobra.Command {
 		Use:   "runtime",
 		Short: "Manage the runtime used by PDK.",
 		Long:  "Manage the runtime used by PDK.",
-		Run:   nil,
 	}
 
 	cmd.AddCommand(getStatusCmd())

--- a/cmd/runtime/status.go
+++ b/cmd/runtime/status.go
@@ -7,8 +7,12 @@ func getStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Shows the status of the runtime.",
 		Long:  "Shows the status of the runtime.",
-		RunE:  nil,
+		RunE:  statusRunE,
 	}
 
 	return cmd
+}
+
+func statusRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -12,8 +12,12 @@ func GetValidateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates Puppet Content with a given tool.",
 		Long:  "Validates Puppet Content with a given tool.",
-		RunE:  nil,
+		RunE:  validateRunE,
 	}
 
 	return cmd
+}
+
+func validateRunE(cmd *cobra.Command, args []string) error {
+	return nil
 }


### PR DESCRIPTION
Commands without a Run/RunE will not show as proper commands in the cli help.

Instead they show as additional help topics.

This commit fixes that by adding empty run methods where needed.